### PR TITLE
Implement the `skill_stage` feature

### DIFF
--- a/src/game/g_main.c
+++ b/src/game/g_main.c
@@ -58,6 +58,12 @@ cvar_t *g_footsteps;
 cvar_t *g_fix_triggered;
 cvar_t *g_commanderbody_nogod;
 
+// Q25_Unit Additions
+
+cvar_t *skill_stage;
+
+// End of Q25 Unit Additions
+
 cvar_t *filterban;
 
 cvar_t *sv_maxvelocity;

--- a/src/game/g_spawn.c
+++ b/src/game/g_spawn.c
@@ -293,6 +293,28 @@ ED_CallSpawn(edict_t *ent)
 		return;
 	}
 
+	// Q2 25
+	// Skill Stage checks
+	/* NOTE(Fix):
+	 * Our maps are available all at once
+	 * So, in order to provide a more interesting experience,
+	 * we made a cvar and some entity fields that are used to toggle entities
+	 * skill_stage to start appearing - 0 always appears
+	 * skill_stage_stop to stop appearing - 0 never disappears
+	 */
+
+	if(ent->skill_stage > skill_stage->value)
+	{
+		G_FreeEdict(ent);
+		return;
+	}
+
+	if(ent->skill_stage_stop > 0 && ent->skill_stage_stop <= skill_stage->value)
+	{
+		G_FreeEdict(ent);
+		return;
+	}
+
 	/* check item spawn functions */
 	for (i = 0, item = itemlist; i < game.num_items; i++, item++)
 	{

--- a/src/game/g_target.c
+++ b/src/game/g_target.c
@@ -433,6 +433,19 @@ use_target_changelevel(edict_t *self, edict_t *other, edict_t *activator)
 		}
 	}
 
+	// Q2 25
+	// NOTE(Fix)
+	/* target_changelevel can increment the skill_stage
+	*  default is off, if you want this on, turn on spawnflag 1
+	*/
+	if(self->spawnflags & SPAWNFLAG_INCREMENT_SKILL_STAGE)
+	{
+		//NOTE(Fix): If we use cvar_set, that tries to change it as if the user
+		// 			 entered it via console. We have to make sure this increments.
+		gi.cvar_forceset("skill_stage", va("%d", (int)skill_stage->value + 1));
+	}
+	// End Q2 25
+
 	/* if noexit, do a ton of damage to other */
 	if (deathmatch->value && !((int)dmflags->value & DF_ALLOW_EXIT) &&
 		(other != world))

--- a/src/game/header/local.h
+++ b/src/game/header/local.h
@@ -524,6 +524,10 @@ extern cvar_t *g_footsteps;
 extern cvar_t *g_fix_triggered;
 extern cvar_t *g_commanderbody_nogod;
 
+// Q25
+extern cvar_t *skill_stage;
+// End of Q25
+
 extern cvar_t *filterban;
 
 extern cvar_t *sv_gravity;
@@ -988,6 +992,11 @@ struct edict_s
 	char *message;
 	char *classname;
 	int spawnflags;
+	
+	// Q2 25
+	int skill_stage;
+	int skill_stage_stop;
+	// End Q2 25
 
 	float timestamp;
 
@@ -1092,6 +1101,7 @@ struct edict_s
 	/* common data blocks */
 	moveinfo_t moveinfo;
 	monsterinfo_t monsterinfo;
+
 };
 
 #endif /* GAME_LOCAL_H */

--- a/src/game/header/local.h
+++ b/src/game/header/local.h
@@ -60,6 +60,12 @@
 #define SPAWNFLAG_NOT_DEATHMATCH 0x00000800
 #define SPAWNFLAG_NOT_COOP 0x00001000
 
+// Q2 25
+
+#define SPAWNFLAG_INCREMENT_SKILL_STAGE 1
+
+// End Q2 25
+
 #define FL_FLY 0x00000001
 #define FL_SWIM 0x00000002 /* implied immunity to drowining */
 #define FL_IMMUNE_LASER 0x00000004

--- a/src/game/savegame/savegame.c
+++ b/src/game/savegame/savegame.c
@@ -248,6 +248,12 @@ InitGame(void)
 	g_fix_triggered = gi.cvar ("g_fix_triggered", "0", 0);
 	g_commanderbody_nogod = gi.cvar("g_commanderbody_nogod", "0", CVAR_ARCHIVE);
 
+	//Q25
+	
+	skill_stage = gi.cvar("skill_stage", "0", CVAR_LATCH);
+
+	// end of Q25
+
 	/* change anytime vars */
 	dmflags = gi.cvar("dmflags", "0", CVAR_SERVERINFO);
 	fraglimit = gi.cvar("fraglimit", "0", CVAR_SERVERINFO);

--- a/src/game/savegame/tables/fields.h
+++ b/src/game/savegame/tables/fields.h
@@ -105,4 +105,6 @@
 {"minpitch", STOFS(minpitch), F_FLOAT, FFL_SPAWNTEMP},
 {"maxpitch", STOFS(maxpitch), F_FLOAT, FFL_SPAWNTEMP},
 {"nextmap", STOFS(nextmap), F_LSTRING, FFL_SPAWNTEMP},
+{"skill_stage", FOFS(skill_stage), F_INT},
+{"skill_stage_stop", FOFS(skill_stage_stop), F_INT},
 {0, 0, 0, 0}


### PR DESCRIPTION
`skill_stage` cvar is used to determine when should an entity start or stop disappearing, based on the completion of previous maps.

Entities also gained 2 new fields
`skill_stage` and `skill_stage_stop`

`skill_stage` determines when the entity will start appearing - 0 is always, 1 is after 1 level has been completed, etc.
`skill_stage_stop` determines when the entity will start disappearing - 0 is never, 1 is after 1 level has been completed, etc.